### PR TITLE
Merchant order

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -156,3 +156,8 @@ td, th {
 tr:nth-child(even) {
   background-color: #F0F8FF;
 }
+
+.item-image {
+  width: 150px;
+  height: 100px;
+}

--- a/app/controllers/merchant/item_orders_controller.rb
+++ b/app/controllers/merchant/item_orders_controller.rb
@@ -1,0 +1,10 @@
+class Merchant::ItemOrdersController < Merchant::BaseController
+  def update
+    io = ItemOrder.find(params[:id])
+    io.update_attribute(:order_status, 'fulfilled')
+    item = Item.find(io.item_id)
+    item.update_quantity_purchased(io.quantity)
+    flash[:success] = "Item is now fulfilled"
+    redirect_to "/merchant/orders/#{io.order_id}"
+  end
+end

--- a/app/controllers/merchant/orders_controller.rb
+++ b/app/controllers/merchant/orders_controller.rb
@@ -1,0 +1,5 @@
+class Merchant::OrdersController < Merchant::BaseController
+  def show
+    @order = Order.find(params[:id])
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -24,6 +24,6 @@ class Order <ApplicationRecord
   end
 
   def merchant_items(merch_id)
-    items.select("items.id, items.name, items.image, items.price, item_orders.quantity").joins(:item_orders).where(merchant_id: merch_id)
+    items.select("items.id, items.name, items.image, items.price, items.inventory, item_orders.order_status, item_orders.quantity, item_orders.id as io_id").joins(:item_orders).where(merchant_id: merch_id)
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -22,4 +22,8 @@ class Order <ApplicationRecord
       update_attribute(:order_status, 'packaged')
     end
   end
+
+  def merchant_items(merch_id)
+    items.select("items.id, items.name, items.image, items.price, item_orders.quantity").joins(:item_orders).where(merchant_id: merch_id)
+  end
 end

--- a/app/views/merchant/dashboard/index.html.erb
+++ b/app/views/merchant/dashboard/index.html.erb
@@ -7,7 +7,7 @@
 <% @orders.each do |order| %>
 <div id="orders-<%= order.id %>">
   <ul>
-    <li>Order ID: <%= order.id %></li>
+    <li>Order ID: <%= link_to order.id, "/merchant/orders/#{order.id}" %></li>
     <li>Order Date: <%= order.created_at %></li>
     <li>Total Quantity: <%= order.total_quantity %></li>
     <li>Total Value: <%= order.grandtotal %></li>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -15,6 +15,8 @@
 
     <% if item.quantity <= item.inventory && item.order_status == 'unfulfilled'%>
       <%= button_to 'Fulfill Order', "/merchant/orders/items/#{item.io_id}", method: :patch %>
+    <% else %>
+    Not enough in inventory to fulfull
     <% end %>
 
   </div>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -1,0 +1,15 @@
+<h1>Recipent Information</h1>
+<ul>
+  <li>Name: <%= @order.name %></li>
+  <li>Address: <%= @order.address %></li>
+</ul>
+
+<h1>My items from order:</h1>
+<% @order.merchant_items(current_user.merchant_id).each do |item| %>
+  <div id="item-<%= item.id %>">
+    <%= image_tag item.image%><br><br>
+    <%= link_to item.name, "/merchant/orders/#{@order.id}/items/#{item.id}" %><br>
+    <%= item.price %>
+    <%= item.quantity %>
+  </div>
+<% end %>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -4,12 +4,19 @@
   <li>Address: <%= @order.address %></li>
 </ul>
 
-<h1>My items from order:</h1>
+<h1>My items for order <%= @order.id %> </h1>
 <% @order.merchant_items(current_user.merchant_id).each do |item| %>
   <div id="item-<%= item.id %>">
-    <%= image_tag item.image%><br><br>
-    <%= link_to item.name, "/merchant/orders/#{@order.id}/items/#{item.id}" %><br>
-    <%= item.price %>
-    <%= item.quantity %>
+    <%= image_tag item.image, class: 'item-image' %><br><br>
+    Item name: <%= link_to item.name, "/merchant/orders/#{@order.id}/items/#{item.id}" %><br>
+    Item price: $<%= item.price %><br>
+    Item quantity: <%= item.quantity %><br>
+    Item status: <%= item.order_status %>
+
+    <% if item.quantity <= item.inventory && item.order_status == 'unfulfilled'%>
+      <%= button_to 'Fulfill Order', "/merchant/orders/items/#{item.io_id}", method: :patch %>
+    <% end %>
+
   </div>
+  <hr>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
     get '/', to: 'dashboard#index'
     get '/dashboard', to: 'dashboard#index'
     get '/items', to: 'items#index'
+    get '/orders/:id', to: 'orders#show'
   end
 
   namespace :admin do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
     get '/dashboard', to: 'dashboard#index'
     get '/items', to: 'items#index'
     get '/orders/:id', to: 'orders#show'
+    patch 'orders/items/:id', to: 'item_orders#update'
   end
 
   namespace :admin do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,10 @@
 Merchant.destroy_all
 Item.destroy_all
 
+#merchants
+bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+
 #user/merchant/admin
 @user = User.create!(name: 'Billy Joel',
                     address: '123 Song St.',
@@ -26,7 +30,8 @@ Item.destroy_all
                         zip: '12345',
                         email: 'merchant',
                         password: '123',
-                        role: 1)
+                        role: 1,
+                        merchant_id: bike_shop.id)
 
 @admin = User.create!(name: 'Chilly Billy',
                       address: '125 Song St.',
@@ -36,10 +41,6 @@ Item.destroy_all
                       email: 'admin',
                       password: '123',
                       role: 2)
-
-#merchants
-bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
 
 #bike_shop items
 tire = bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12, quantity_purchased: 0)

--- a/spec/features/merchant_users/orders/show_spec.rb
+++ b/spec/features/merchant_users/orders/show_spec.rb
@@ -87,5 +87,18 @@ RSpec.describe 'Merchant orders show page'do
         expect(page).to_not have_button("Fulfill Order")
       end
     end
+
+    it 'cannot fulfull and order if it lacks the inventory' do
+      @paper.update_attribute(:inventory, 1)
+
+      visit "/merchant/orders/#{@order_1.id}"
+
+      within "#item-#{@paper.id}" do
+        expect(page).to have_content(@io1.order_status)
+        expect(page).to_not have_button("Fulfill Order")
+        expect(page).to have_content("Not enough in inventory to fulfull")
+      end
+
+    end
   end
 end

--- a/spec/features/merchant_users/orders/show_spec.rb
+++ b/spec/features/merchant_users/orders/show_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant orders show page'do
+  before :each do
+    @print_shop = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    @bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+
+    @paper = @print_shop.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 5)
+    @pencil = @print_shop.items.create(name: "Yellow Pencil", description: "You can write on paper with it!", price: 2, image: "https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg", inventory: 100)
+    @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+
+    @user = User.create!(name: 'Billy Joel',
+                        address: '123 Song St.',
+                        city: 'Las Vegas',
+                        state: 'NV',
+                        zip: '12345',
+                        email: 'billy_j@user.com',
+                        password: '123',
+                        role: 0)
+
+    @order_1 = @user.orders.create!(name: 'Billy Joel', address: '1616 Bedford Ave', city: 'Hershey', state: 'PA', zip: 17033)
+    @io1 = @order_1.item_orders.create!(item: @paper, price: @paper.price, quantity: 2)
+    @io2 = @order_1.item_orders.create!(item: @pencil, price: @pencil.price, quantity: 3)
+    @io3 = @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 1)
+
+    @merchant = User.create!(name: 'Joel Billy',
+                            address: '125 Song St.',
+                            city: 'Las Vegas',
+                            state: 'NV',
+                            zip: '12345',
+                            email: 'merchant',
+                            merchant_id: @print_shop.id,
+                            password: '123',
+                            role: 1)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+  end
+
+  describe 'a merchant' do
+    it 'can visit their order show page' do
+      visit '/merchant/dashboard'
+
+      within "#orders-#{@order_1.id}" do
+        click_link "#{@order_1.id}"
+      end
+
+      expect(current_path).to eq("/merchant/orders/#{@order_1.id}")
+
+      within "#item-#{@paper.id}" do
+        expect(page).to have_link(@paper.name)
+        expect(page).to have_xpath("//img['#{@paper.image}']")
+        expect(page).to have_content(@paper.price)
+        expect(page).to have_content(@io1.quantity)
+      end
+
+      within "#item-#{@pencil.id}" do
+        expect(page).to have_link(@pencil.name)
+        expect(page).to have_xpath("//img['#{@pencil.image}']")
+        expect(page).to have_content(@pencil.price)
+        expect(page).to have_content(@io2.quantity)
+      end
+
+      expect(page).to_not have_content(@tire.name)
+      expect(page).to_not have_content(@tire.name)
+      expect(page).to_not have_content(@tire.price)
+    end
+  end
+end

--- a/spec/features/merchant_users/orders/show_spec.rb
+++ b/spec/features/merchant_users/orders/show_spec.rb
@@ -64,5 +64,28 @@ RSpec.describe 'Merchant orders show page'do
       expect(page).to_not have_content(@tire.name)
       expect(page).to_not have_content(@tire.price)
     end
+
+    it 'can each items status and has a button to fulfill if item is unfulfilled' do
+      visit "/merchant/orders/#{@order_1.id}"
+
+      within "#item-#{@paper.id}" do
+        expect(page).to have_content(@io1.order_status)
+        expect(page).to have_button("Fulfill Order")
+      end
+
+      within "#item-#{@pencil.id}" do
+        expect(page).to have_content(@io2.order_status)
+        expect(page).to have_button("Fulfill Order")
+        click_button 'Fulfill Order'
+      end
+
+      expect(current_path).to eq("/merchant/orders/#{@order_1.id}")
+      expect(page).to have_content("Item is now fulfilled")
+
+      within "#item-#{@pencil.id}" do
+        expect(page).to have_content("Item status: fulfilled")
+        expect(page).to_not have_button("Fulfill Order")
+      end
+    end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -57,5 +57,17 @@ describe Order, type: :model do
       @order_1.change_status_packaged
       expect(@order_1.order_status).to eq('packaged')
     end
+
+    it 'merchant_items' do
+      expect(@order_1.merchant_items(@meg.id).length).to eq(1)
+      expect(@order_1.merchant_items(@meg.id).first.id).to eq(@tire.id)
+      expect(@order_1.merchant_items(@meg.id).first.name).to eq(@tire.name)
+      expect(@order_1.merchant_items(@meg.id).first.image).to eq(@tire.image)
+      expect(@order_1.merchant_items(@meg.id).first.price).to eq(@tire.price)
+      expect(@order_1.merchant_items(@meg.id).first.inventory).to eq(@tire.inventory)
+      expect(@order_1.merchant_items(@meg.id).first.order_status).to eq(@io1.order_status)
+      expect(@order_1.merchant_items(@meg.id).first.quantity).to eq(@io1.quantity)
+      expect(@order_1.merchant_items(@meg.id).first.io_id).to eq(@io1.id)
+    end
   end
 end


### PR DESCRIPTION
User stories 49-50

**User Story 49, Merchant sees an order show page**

As a merchant employee
When I visit an order show page from my dashboard
I see the recipients name and address that was used to create this order
I only see the items in the order that are being purchased from my merchant
I do not see any items in the order being purchased from other merchants
For each item, I see the following information:
- the name of the item, which is a link to my item's show page
- an image of the item
- my price for the item
- the quantity the user wants to purchase

**User Story 50, Merchant fulfills part of an order**

As a merchant employee
When I visit an order show page from my dashboard
For each item of mine in the order
If the user's desired quantity is equal to or less than my current inventory quantity for that item
And I have not already "fulfilled" that item:
- Then I see a button or link to "fulfill" that item
- When I click on that link or button I am returned to the order show page
- I see the item is now fulfilled
- I also see a flash message indicating that I have fulfilled that item
- the item's inventory quantity is permanently reduced by the user's desired quantity

If I have already fulfilled this item, I see text indicating such.

**User Story 51, Merchant cannot fulfill an order due to lack of inventory**

As a merchant employee
When I visit an order show page from my dashboard
For each item of mine in the order
If the user's desired quantity is greater than my current inventory quantity for that item
Then I do not see a "fulfill" button or link
Instead I see a notice next to the item indicating I cannot fulfill this item
